### PR TITLE
Prepare for Meteor 0.9's packaging system

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Installation
 -------------
 
-`mrt add moment`
+`meteor add acreeger:moment`
 
 Usage
 -------------

--- a/package.js
+++ b/package.js
@@ -1,11 +1,12 @@
 Package.describe({
-  summary: "Moment.js, a JavaScript date library for parsing, validating, manipulating, and formatting dates, packaged for Meteor. See http://momentjs.com."
+  summary: "Moment.js, a JavaScript date library for parsing, validating, manipulating, and formatting dates, packaged for Meteor. See http://momentjs.com.",
+  version: "2.6.0",
+  git: "https://github.com/acreeger/meteor-moment.git"
 });
 
 Package.on_use(function (api, where) {
-  if(api.export) {
-    api.export('moment');
-  }
+  api.export('moment', where);
+
   where = where || ['client', 'server'];
   api.add_files('lib/moment/moment.js', where);
   api.add_files('export-moment.js', where);

--- a/smart.json
+++ b/smart.json
@@ -1,8 +1,0 @@
-{
-  "name": "moment",
-  "description": "Moment.js, a JavaScript date library for parsing, validating, manipulating, and formatting dates, packaged for Meteor. See http://momentjs.com.",
-  "homepage": "https://github.com/acreeger/meteor-moment",
-  "author": "Adam Creeger <adamcreeger@gmail.com> (http://acree.gr)",
-  "version": "2.6.0",
-  "git": "https://github.com/acreeger/meteor-moment.git"
-}

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,15 @@
+{
+  "dependencies": [
+    [
+      "meteor",
+      "1.0.2"
+    ],
+    [
+      "underscore",
+      "1.0.0"
+    ]
+  ],
+  "pluginDependencies": [],
+  "toolVersion": "meteor-tool@1.0.8",
+  "format": "1.0"
+}


### PR DESCRIPTION
I've been using your package as part of a migration to Meteor 0.9 and so I've updated it to work with the new system.

Note that your package was migrated as `mrt:moment@2.6.0` which you will probably want to re-publish as `acreeger:moment@2.6.0` or whatever name you want.

There are still some kinks being worked out; see https://hackpad.com/Migrating-Packages-zN0we9sIjkH and https://meteor.hackpad.com/Unipackage-tvas8pXYMOW#:h=Publishing-a-New-Package.

Let me know if I can help with any issues. The big discussion thread is over at https://groups.google.com/forum/#!topic/meteor-talk/VUaWMwV7aHM.
